### PR TITLE
Added upper case characters to regex

### DIFF
--- a/pkg/catalog/utils/version/version.go
+++ b/pkg/catalog/utils/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	numberRe = regexp.MustCompile("[0-9]+")
-	wordRe   = regexp.MustCompile("[a-z]+")
+	wordRe   = regexp.MustCompile("[a-zA-Z]+")
 )
 
 func GreaterThan(a, b string) bool {


### PR DESCRIPTION
Here ( https://semver.org/#spec-item-9 ) it says that uppercase characters are ok to use:

A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers immediately following the patch version. Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9 A-Z a-z-].
